### PR TITLE
Internal ggsashimi docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,147 +1,42 @@
 # ggsashimi
 
-[![Build Status](https://github.com/guigolab/ggsashimi/workflows/CI/badge.svg)](https://github.com/guigolab/ggsashimi/actions)
-
-Command-line tool for the visualization of splicing events across multiple samples
-
-**[Installation](#installation)**<br>
-&ensp; **[Dependencies](#dependencies)**<br>
-&ensp; **[Download docker image](#download-docker-image)**<br>
-&ensp; **[Build docker image](#build-docker-image)**<br>
-&ensp; **[Use docker image](#use-docker-image)**<br>
-**[Usage](#usage)**<br>
-**[Galaxy](#galaxy)**<br>
-**[Cite ggsashimi](#cite-ggsashimi)**
-
-![image](sashimi.png)
+Command-line tool for the visualization of splicing events across multiple samples, adapted for use with rokita-lab and mounting cavatica project bams on an EC2 instance.
 
 ## Installation<a name="installation"></a>
 
-The `ggsashimi` script can be directly downloaded from this repository:
+From an EC2 instance:
 
-```shell
-wget https://raw.githubusercontent.com/guigolab/ggsashimi/master/ggsashimi.py
+1. Clone the repository:
+```
+git clone git@github.com:rokitalab/splicing-variants.git
 ```
 
-Change the execution permissions:
-
-```shell
-chmod u+x ggsashimi.py
+2. Pull Docker container:
+```
+docker pull pgc-images.sbgenomics.com/rokita-lab/ggsashimi:latest
 ```
 
-Provided all dependencies are already installed (see below), you can directly execute the script:
+3. Start the Docker container from the `ggsashimi` folder:
+```
+docker run --privileged --name <NAME> -d -e PASSWORD=<ANYTHING> -p 80:8787 -v $PWD:/home/rstudio/ggsashimi pgc-images.sbgenomics.com/rokita-lab/ggsashimi:latest
+```
+To launch Rstudio in your browser, navigate to the instance IP address in your web browser. The username for login is rstudio and the password is set in the docker run command above.
 
-```shell
-./ggsashimi.py --help
+Or access the docker container via command line 
+```
+docker exec --privileged -ti <NAME> bash
 ```
 
-To download the entire repository, which includes the dockerfile and example files:
+4. Configure SBFS credentials: 
+Run `sbfs configure` and enter the following when prompted:
+API endpoint [None]: `https://cavatica-api.sbgenomics.com/v2`
+Authentication token [None]: (personal CAVATICA authentication token)
+NOTE: these parameters will automatically be assigned as the “default” profile in the configuration file.
 
-```shell
-git clone https://github.com/guigolab/ggsashimi.git
+5. Mount a cavatica project to the data directory:
+```
+mkdir data/cavativa
+sbfs mount --profile default --project sicklera/pbta-and-normal-crams data/cavatica
 ```
 
-### Dependencies<a name="dependencies"></a>
-
-In order to run `ggsashimi` the following software components and packages are required:
-
-- python (2.7 or 3)
-- pysam (>=0.10.0)
-- R (>=3.3)
-  - ggplot2 (>=2.2.1)
-  - data.table (>=1.10.4)
-  - gridExtra (>=2.2.1)
-
-Additional required R packages `grid` and `gtable` should be automatically installed when installing R and `ggplot2`, respectively. Package `svglite` (>=1.2.1) is also required when generating output images in SVG format.
-
-To avoid dependencies issues, the script is also available through a docker image.
-
-### Download docker image <a name="download-docker-image"></a>
-
-A public `ggsashimi` Docker image is available in the [Docker Hub](https://hub.docker.com/r/guigolab/ggsashimi/) and can be downloaded as follows:
-
-```shell
-docker pull guigolab/ggsashimi
-```
-
-__Alternatively__, we provide the Dockerfile if you want to build your local docker image, although most users will not need it.
-
-### Build docker image (optional) <a name="build-docker-image"></a>
-
-After downloading the repository, move inside the repository folder:
-
-```shell
-cd ggsashimi
-```
-
-To build the docker image run the following command:
-
-```shell
-docker build -f docker/Dockerfile -t guigolab/ggsashimi .
-```
-
-This can take several minutes.
-
-### Use docker image <a name="use-docker-image"></a>
-
-Once the image is downloaded or built, to execute ggsashimi with docker:
-
-```shell
-docker run guigolab/ggsashimi --help
-```
-
-Because the image is used in a docker container which has its own file system, to use the program with local files, a host data volume needs to be mounted.
-
-As an example, you can run this command from the main repository folder:
-
-```shell
-docker run -w $PWD -v $PWD:$PWD guigolab/ggsashimi -b examples/input_bams.tsv -c chr10:27040584-27048100
-```
-
-The '-w' option sets the working directory inside the container to the current directory.
-The '-v' option mounts the current working directory and all child folders inside the container to the same path (host_path:container_path).
-
-If your files are in another folder, for example the annotation file is stored in a different folder then the one containing the bam file, you can mount extra folders like this:
-
-```shell
-f="$DIR/annotation.gtf"
-docker run -w $PWD -v $PWD:$PWD -v $DIR:$DIR guigolab/ggsashimi -b examples/input_bams.tsv -c chr10:27040584-27048100 -g $f
-```
-
-You can even mount a single file:
-
-```shell
-docker run -w $PWD -v $PWD:$PWD -v $f:$f guigolab/ggsashimi -b examples/input_bams.tsv -c chr10:27040584-27048100 -g $f
-```
-
-## Usage <a name="usage"></a>
-
-Execute the script with `--help` option for a complete list of options.
-Sample data and usage examples can be found at `examples`
-
-### Debug mode
-
-Debug mode allows to run `ggsashimi` without producing any graphical output. It creates an `Rscript` file in the current working folder, containing all the R commands to generate the plot. It can be useful when reporting bugs or trying to debug the program behavior. Debug mode can be enabled by setting the environment variable `GGSASHIMI_DEBUG` when running the script, e.g.:
-
-```
-# export the environment variable
-$ export GGSASHIMI_DEBUG=yes
-$ ggsashimi.py -b ...
-```
-
-or
-
-```
-# set the environment variable inline
-$ GGSASHIMI_DEBUG=yes ggsashimi.py -b ...
-```
-
-## Galaxy <a name="galaxy"></a>
-
-Thanks to [ARTbio](https://github.com/ARTbio), now a [Galaxy](https://galaxyproject.org) wrapper for `ggsashimi` is available at the [Galaxy ToolShed](https://toolshed.g2.bx.psu.edu/repository?repository_id=397283a49b821a79&changeset_revision=64aa67b5099f).
-
-## Cite ggsashimi <a name="cite-ggsashimi"></a>
-
-If you find `ggsashimi` useful in your research please cite the related publication:
-
-[Garrido-Martín, D., Palumbo, E., Guigó, R., & Breschi, A. (2018). ggsashimi: Sashimi plot revised for browser-and annotation-independent splicing visualization. _PLoS computational biology, 14_(8), e1006360.](https://doi.org/10.1371/journal.pcbi.1006360)
+To unmount, run `sbfs unmount <mount_dir>`

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,12 @@
-ARG UBUNTU_VERSION=20.04
-FROM ubuntu:${UBUNTU_VERSION} as builder
+FROM rocker/tidyverse:4.4.0
+LABEL maintainer="psullivan@childrensnational.org"
+WORKDIR /rocker-build/
+
+# update and upgrade packages
+RUN apt-get -y update --fix-missing \
+    && apt-get -y upgrade \
+    && apt-get -y update \
+    && apt-get -y autoremove
 
 # install needed tools
 RUN apt-get update \
@@ -11,7 +18,18 @@ RUN apt-get update \
          libfontconfig1-dev \
          lsb-release \
          python3-pip \
-         python-is-python3
+         python-is-python3 \
+         fuse \
+         wget \
+         tar \
+         git \
+         man-db \
+         unzip \
+         openjdk-17-jdk \
+         vim
+
+# install CAVATICA SBFS
+RUN curl https://igor.sbgenomics.com/downloads/sbfs/install.sh -sSf | sudo sh
 
 # install R
 ARG R_VER=3.6.3
@@ -26,24 +44,24 @@ RUN echo 'options(repos = "https://cloud.r-project.org/")' > ~/.Rprofile
 ## Install R packages
 ARG GGPLOT_VER=3.3.3
 RUN R -e 'install.packages("remotes");' && \
+    R -e 'remotes::install_version("rlang", version="0.4.10")' && \
+    R -e 'remotes::install_version("vctrs", version="0.3.6")' && \
+    R -e 'remotes::install_version("pillar", version="1.4.7")' && \
+    R -e 'remotes::install_version("tibble", version="3.0.6")' && \
+    R -e 'remotes::install_version("gtable", version="0.3.0")' && \
+    R -e 'remotes::install_version("scales", version="1.1.1")' && \
     R -e 'remotes::install_version("ggplot2", version="'${GGPLOT_VER}'")' && \
     R -e 'remotes::install_cran(c("gridExtra", "data.table", "svglite"))'
 
 # Install pysam
 RUN pip3 install pysam
 
-FROM ubuntu:${UBUNTU_VERSION}
-
-LABEL maintainer "Emilio Palumbo <emilio.palumbo@crg.eu>" \
-      version "1.0" \
-      description "Docker image for ggsashimi"
 
 # install needed tools
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libblas3 \
         libgomp1 \
-        libicu66 \
         liblapack3 \
         locales \
         python-is-python3
@@ -59,13 +77,28 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     PATH=/opt/R/${R_VER}/bin:$PATH
 
-# Copy installed libraries from builder
-COPY --from=builder /opt/R /opt/R
-COPY --from=builder /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.8/dist-packages
+# install samtools
+RUN apt-get update && apt-get -y upgrade && \
+        apt-get install -y build-essential wget \
+                libncurses5-dev zlib1g-dev libbz2-dev liblzma-dev libcurl3-dev && \
+        apt-get clean && apt-get purge && \
+        rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /usr/src
+
+#Samtools
+RUN wget https://github.com/samtools/samtools/releases/download/1.21/samtools-1.21.tar.bz2 && \
+        tar jxf samtools-1.21.tar.bz2 && \
+        rm samtools-1.21.tar.bz2 && \
+        cd samtools-1.21 && \
+        ./configure --prefix $(pwd) && \
+        make
+
+ENV PATH=${PATH}:/usr/src/samtools-1.21
 
 # Copy ggsashimi in the docker image
-ADD ggsashimi.py /
+# ADD ggsashimi.py /
 
 # Run the container as an executable
-ENTRYPOINT ["/ggsashimi.py"]
+# ENTRYPOINT ["/ggsashimi.py"]
 


### PR DESCRIPTION
Closes #2 

Add sbfs to docker
Add samtools to docker

Run docker following the instructions in the readme.
Run checks for:
- samtools
- R v3.6.3
- ggsashimi `python3 /home/rstudio/ggsashimi/ggsashimi.py --help`

Following the README, ensure that you can mount sicklera/pbta-and-normal-crams. 